### PR TITLE
feat: specify Node.js engine version and update Vercel function runtime

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,3 @@
+# Vitest suites under api/ must not be uploaded: each top-level file in api/ becomes a
+# Serverless Function (Hobby plan max 12). Shared code stays in api/_lib/ (ignored as routes).
+api/**/*.test.ts

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.json && vite build",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "api/stripe-webhook.ts": { "runtime": "nodejs18.x", "memory": 512, "maxDuration": 10 }
+    "api/stripe-webhook.ts": { "memory": 512, "maxDuration": 10 }
   }
 }
 


### PR DESCRIPTION
- Add Node.js engine version requirement (20.x) in package.json for compatibility.
- Remove explicit runtime version for the stripe webhook function in vercel.json to allow automatic updates.