### PR TITLE
Add cart validation for unpriceable lines to optimize API calls

### DIFF
--- a/src/cart/reconcile.ts
+++ b/src/cart/reconcile.ts
@@ -251,6 +251,27 @@ export function isCartOkForCheckout(validation: CartLineValidation[]): boolean {
 }
 
 /**
+ * `true` when at least one line references something the server can't price
+ * (unknown product/SKU or a legacy multi-variant line missing its SKU).
+ * Stock/quantity issues are excluded — those still quote successfully server-side.
+ *
+ * Callers use this to suppress `/api/cart-quote` calls that we know will 400.
+ */
+export function cartHasUnpriceableLine(
+  validation: CartLineValidation[] | null | undefined,
+): boolean {
+  if (!validation) return false;
+  return validation.some((v) =>
+    v.issues.some(
+      (i) =>
+        i.code === "unknown_sku" ||
+        i.code === "unknown_product" ||
+        i.code === "missing_variant",
+    ),
+  );
+}
+
+/**
  * Refresh catalog-backed fields without removing lines. Fills SKU for single-variant products.
  */
 export function syncCartLinesFromCatalog(

--- a/src/components/Cart/CartPage.tsx
+++ b/src/components/Cart/CartPage.tsx
@@ -4,6 +4,7 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
 import { normalizeLineSku } from "../../cart/lineKey";
 import {
+  cartHasUnpriceableLine,
   isCartOkForCheckout,
   validateStorefrontCartLines,
 } from "../../cart/reconcile";
@@ -92,8 +93,9 @@ const CartPage: React.FC = () => {
     cartItems.length > 0 &&
     isCartOkForCheckout(validations);
 
+  const skipQuote = cartHasUnpriceableLine(validations);
   const { quote, loading: quoteLoading, error: quoteError, refetch: refetchQuote, drafts: checkoutDrafts } =
-    useCartQuote(cartItems);
+    useCartQuote(cartItems, { skip: skipQuote });
 
   const subtotal = useMemo(() => {
     if (!validations) {

--- a/src/components/Cart/CheckoutPage.tsx
+++ b/src/components/Cart/CheckoutPage.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation, useNavigate, useSearchParams } from "react-router-do
 import { ANALYTICS_EVENTS } from "../../analytics/events";
 import { dispatchAnalyticsEvent } from "../../analytics/sink";
 import {
+    cartHasUnpriceableLine,
     isCartOkForCheckout,
     validateStorefrontCartLines,
 } from "../../cart/reconcile";
@@ -144,20 +145,22 @@ const CheckoutPage = () => {
     const [catalogList, setCatalogList] = useState<CatalogListItem[] | null>(null);
     const [catalogError, setCatalogError] = useState(false);
 
-    const {
-        quote,
-        error: cartQuoteError,
-        refetch: refetchCartQuote,
-        drafts: checkoutLines,
-        loading: cartQuoteLoading,
-    } = useCartQuote(cartItems);
-
     const [clientSecret, setClientSecret] = useState<string | null>(null);
 
     const validations = useMemo(() => {
         if (!catalogList) return null;
         return validateStorefrontCartLines(cartItems, catalogList);
     }, [cartItems, catalogList]);
+
+    const skipCartQuote = cartHasUnpriceableLine(validations);
+
+    const {
+        quote,
+        error: cartQuoteError,
+        refetch: refetchCartQuote,
+        drafts: checkoutLines,
+        loading: cartQuoteLoading,
+    } = useCartQuote(cartItems, { skip: skipCartQuote });
 
     const checkoutOk =
         catalogList != null &&

--- a/src/hooks/useCartQuote.ts
+++ b/src/hooks/useCartQuote.ts
@@ -4,10 +4,24 @@ import type { StorefrontCartLine } from "../cart/cartLine";
 import { isServerCartQuote, type ServerCartQuote } from "../lib/cartQuoteTypes";
 import { apiUrl } from "../lib/apiBase";
 
+export type UseCartQuoteOptions = {
+  /**
+   * Suppresses the network call. Use when the cart already has a structural problem
+   * (e.g. unknown SKU after a catalog migration) so the server doesn't 400 redundantly
+   * — the cart-page validation banner already tells the user what to fix.
+   */
+  skip?: boolean;
+};
+
 /**
- * Fetches server catalog quote for current cart. Skips when there are no checkout SKUs.
+ * Fetches server catalog quote for current cart. Skips when there are no checkout SKUs
+ * or when the caller marks the cart as known-bad via `options.skip`.
  */
-export function useCartQuote(cartItems: StorefrontCartLine[]) {
+export function useCartQuote(
+  cartItems: StorefrontCartLine[],
+  options: UseCartQuoteOptions = {},
+) {
+  const { skip = false } = options;
   const drafts = useMemo(() => toCheckoutLines(cartItems), [cartItems]);
 
   const [quote, setQuote] = useState<ServerCartQuote | null>(null);
@@ -20,7 +34,7 @@ export function useCartQuote(cartItems: StorefrontCartLine[]) {
   }, []);
 
   useEffect(() => {
-    if (drafts.length === 0) {
+    if (skip || drafts.length === 0) {
       setQuote(null);
       setError(null);
       setLoading(false);
@@ -78,7 +92,7 @@ export function useCartQuote(cartItems: StorefrontCartLine[]) {
       clearTimeout(t);
       ctrl.abort();
     };
-  }, [drafts, retryToken]);
+  }, [drafts, retryToken, skip]);
 
   return { quote, loading, error, refetch, drafts } as const;
 }


### PR DESCRIPTION
- Introduce `cartHasUnpriceableLine` function to identify cart lines that cannot be priced, enhancing error handling.
- Update `useCartQuote` hook to accept a `skip` option, preventing unnecessary API calls for known bad cart states.
- Integrate `cartHasUnpriceableLine` in `CartPage` and `CheckoutPage` components to conditionally skip quote requests based on validation results.
- Refactor related components to improve clarity and maintainability in handling cart validations.