### PR TITLE
Add tests for variant_options_snapshot handling in create-payment-intent

### DIFF
--- a/handlers/create-payment-intent.handler.test.ts
+++ b/handlers/create-payment-intent.handler.test.ts
@@ -262,4 +262,77 @@ describe("create-payment-intent handler (Stripe create)", () => {
       error_code: "ORDER_INSERT_FAILED/42703",
     });
   });
+
+  it("omits variant_options_snapshot from order_items insert rows when checkout has no template snapshot", async () => {
+    const body = {
+      items: [{ sku: "ZLX-2PK-S", quantity: 1 }],
+      currency: "usd" as const,
+      email: "buyer@example.com",
+    };
+    const req = { method: "POST", body } as VercelRequest;
+    const resJson = vi.fn();
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnValue({ json: resJson }),
+    } as unknown as VercelResponse;
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const insertedRows = orderItemsInsert.mock.calls[0][0] as Record<string, unknown>[];
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0]).not.toHaveProperty("variant_options_snapshot");
+  });
+
+  it("includes variant_options_snapshot on order_items rows when checkout sends variant_display_snapshot", async () => {
+    const snap = [
+      { axis_label: "Size", option_label: "M" },
+      { axis_label: "Color", option_label: "Black" },
+    ];
+    const body = {
+      items: [{ sku: "ZLX-2PK-S", quantity: 1, variant_display_snapshot: snap }],
+      currency: "usd" as const,
+      email: "buyer@example.com",
+    };
+    const req = { method: "POST", body } as VercelRequest;
+    const resJson = vi.fn();
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnValue({ json: resJson }),
+    } as unknown as VercelResponse;
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const insertedRows = orderItemsInsert.mock.calls[0][0] as Record<string, unknown>[];
+    expect(insertedRows[0].variant_options_snapshot).toEqual(snap);
+  });
+
+  it("returns a safe database cause code when order_items insert fails", async () => {
+    orderItemsInsert.mockResolvedValueOnce({
+      error: { code: "42703", message: "column does not exist" },
+    });
+
+    const req = {
+      method: "POST",
+      body: {
+        items: [{ sku: "ZLX-2PK-S", quantity: 1 }],
+        currency: "usd",
+        email: "buyer@example.com",
+      },
+    } as VercelRequest;
+    const resJson = vi.fn();
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnValue({ json: resJson }),
+    } as unknown as VercelResponse;
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(resJson).toHaveBeenCalledWith({
+      error: "Payment setup failed. Please try again.",
+      error_code: "ORDER_ITEMS_INSERT_FAILED/42703",
+    });
+  });
 });

--- a/handlers/create-payment-intent.ts
+++ b/handlers/create-payment-intent.ts
@@ -216,7 +216,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         image_url: row.image_url,
         product_id: row.product_id,
         variant_id: row.variant_id,
-        // Omit key when null — avoids inserts referencing a missing `variant_options_snapshot` column on older DBs.
         ...(row.variant_options_snapshot != null
           ? { variant_options_snapshot: row.variant_options_snapshot }
           : {}),


### PR DESCRIPTION
- Introduce tests to verify the behavior of `variant_options_snapshot` in order_items based on the presence of `variant_display_snapshot` in the request.
- Ensure that the handler correctly omits the `variant_options_snapshot` when no template snapshot is provided and includes it when available.
- Enhance error handling tests to return a safe database cause code for order_items insert failures, improving user feedback during payment setup.