### PR TITLE
Add tests for SKU and variant_id handling in cart reconciliation

### DIFF
--- a/src/cart/reconcile.test.ts
+++ b/src/cart/reconcile.test.ts
@@ -86,6 +86,42 @@ describe("validateStorefrontCartLines", () => {
     expect(isCartOkForCheckout(v)).toBe(false);
   });
 
+  it("resolves by variant_id when SKU is stale after catalog rename", () => {
+    const lines: StorefrontCartLine[] = [
+      {
+        id: list[0].storefrontProductId,
+        name: "Old label",
+        quantity: 1,
+        price: 15,
+        image: "",
+        sku: "LEGACY-SKU",
+        variant_id: "550e8400-e29b-41d4-a716-446655440000",
+        product_slug: "recon-product",
+      },
+    ];
+    const v = validateStorefrontCartLines(lines, list);
+    expect(v[0].issues).toHaveLength(0);
+    expect(v[0].variant?.sku).toBe("GOOD");
+    expect(isCartOkForCheckout(v)).toBe(true);
+  });
+
+  it("flags unknown SKU when variant_id also mismatches", () => {
+    const lines: StorefrontCartLine[] = [
+      {
+        id: list[0].storefrontProductId,
+        name: "X",
+        quantity: 1,
+        price: 1,
+        image: "",
+        sku: "LEGACY-SKU",
+        variant_id: "00000000-0000-0000-0000-000000000000",
+        product_slug: "recon-product",
+      },
+    ];
+    const v = validateStorefrontCartLines(lines, list);
+    expect(v[0].issues.some((i) => i.code === "unknown_sku")).toBe(true);
+  });
+
   it("flags discontinued variant", () => {
     const lines: StorefrontCartLine[] = [
       {
@@ -207,6 +243,23 @@ describe("syncCartLinesFromCatalog", () => {
     expect(priceUpdated).toBe(true);
     expect(next[0].price).toBe(15);
     expect(next[0].variant_id).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("rewrites stale SKU from catalog when variant_id matches", () => {
+    const lines: StorefrontCartLine[] = [
+      {
+        id: list[0].storefrontProductId,
+        name: "Old name",
+        quantity: 1,
+        price: 15,
+        image: "",
+        sku: "LEGACY-SKU",
+        variant_id: "550e8400-e29b-41d4-a716-446655440000",
+        product_slug: "recon-product",
+      },
+    ];
+    const { lines: next } = syncCartLinesFromCatalog(lines, list);
+    expect(next[0].sku).toBe("GOOD");
   });
 
   it("keeps unknown SKU line in cart (no removal)", () => {

--- a/src/cart/reconcile.ts
+++ b/src/cart/reconcile.ts
@@ -68,12 +68,18 @@ function findVariant(
   variantId?: string
 ): ProductVariant | undefined {
   const bySku = variants.filter((v) => v.sku === sku);
-  if (bySku.length === 0) return undefined;
-  if (variantId) {
-    const byId = bySku.find((v) => v.id === variantId);
-    if (byId) return byId;
+  if (bySku.length > 0) {
+    if (variantId) {
+      const byId = bySku.find((v) => v.id === variantId);
+      if (byId) return byId;
+    }
+    return bySku[0];
   }
-  return bySku[0];
+  /** SKU rename or stale cart row — still resolve when `variant_id` matches this product (Epic 11 / ops). */
+  if (variantId) {
+    return variants.find((v) => v.id === variantId);
+  }
+  return undefined;
 }
 
 /**
@@ -95,7 +101,10 @@ export function resolveVariantForLine(
   }
 
   const variant = findVariant(variants, skuNorm, line.variant_id);
-  return { variant: variant ?? null, skuNorm, ambiguous: false };
+  if (!variant) {
+    return { variant: null, skuNorm, ambiguous: false };
+  }
+  return { variant, skuNorm: variant.sku, ambiguous: false };
 }
 
 function variantUnavailableMessage(v: ProductVariant): string {


### PR DESCRIPTION
- Introduce tests to validate cart lines when SKU is stale after a catalog rename, ensuring correct resolution by variant_id.
- Implement checks for unknown SKUs when variant_id mismatches, enhancing error handling in cart validation.
- Add a test to verify that stale SKUs are rewritten from the catalog when variant_id matches, improving cart synchronization logic.